### PR TITLE
Change backlog metric format from decbytes to short

### DIFF
--- a/pulsar/messaging.json
+++ b/pulsar/messaging.json
@@ -318,7 +318,7 @@
               }
             ]
           },
-          "unit": "decbytes"
+          "unit": "short"
         },
         "overrides": []
       },

--- a/pulsar/overview.json
+++ b/pulsar/overview.json
@@ -645,7 +645,7 @@
         },
         "overrides": []
       },
-      "format": "decbytes",
+      "format": "short",
       "gauge": {
         "maxValue": 100,
         "minValue": 0,


### PR DESCRIPTION
Hi @lhotari,
First of all, thanks for providing these Grafana dashboards for Pulsar.
I propose a little fix, changing the backlog metric format from decbytes to short.